### PR TITLE
Don't fail on events with no dtend

### DIFF
--- a/lib/magical/parser.ex
+++ b/lib/magical/parser.ex
@@ -90,4 +90,5 @@ defmodule Magical.Parser do
 
   defp resolve_time_zones(%Date{} = date, _time_zone), do: date
   defp resolve_time_zones(%DateTime{} = date_time, _time_zone), do: date_time
+  defp resolve_time_zones(nil, _time_zone), do: nil
 end

--- a/test/magical/parser_test.exs
+++ b/test/magical/parser_test.exs
@@ -106,4 +106,29 @@ defmodule Magical.ParserTest do
            } =
              calendar
   end
+
+  describe "time zone resolution" do
+    test "gracefully handles nil start or end times" do
+      expected_dtstart = DateTime.shift_zone!(~U[2025-04-16 12:00:00Z], "Europe/Paris")
+
+      {:ok,
+       %Magical.Calendar{
+         events: [
+           %Magical.Event{
+             dtstart: ^expected_dtstart,
+             dtend: nil
+           }
+         ]
+       }} =
+        """
+        BEGIN:VCALENDAR
+        X-WR-TIMEZONE:Europe/Paris
+        BEGIN:VEVENT
+        DTSTART:20250416T140000
+        END:VEVENT
+        END:VCALENDAR
+        """
+        |> Parser.parse()
+    end
+  end
 end


### PR DESCRIPTION
I ran the parser on my google calendar export (after the fixes from https://github.com/jonathanballs/magical/pull/2), and I noticed that I have events with a `DTSTART` and no `DTEND`, which the parser doesn't like. This PR ensures that we can resolve the `nil` dtend to `nil` :)

I couldn't find place where a test would fit, but I'm happy to add one if you point me in the right direction.